### PR TITLE
Correct chmod path and incorporate build information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 NAME = tinyirc
-
 PREFIX = /usr/local
+VERSION = 0.1.0
+BUILD_TIME = $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 
 ${NAME}:
-	go build -o ${NAME} main.go
+	go build -ldflags "-X main.version=$(VERSION) -X main.buildTime=$(BUILD_TIME)" -o ${NAME} main.go
 
 clean:
 	rm -f ${NAME}
@@ -11,7 +12,7 @@ clean:
 install: ${NAME}
 	cp -f ${NAME} "${DESTDIR}${PREFIX}/bin"
 	cp -f ${NAME}.1 "${DESTDIR}${PREFIX}/man/man1/"
-	chmod 755 "${DESTDIR}${PREFIX}/bin/${BIN}"
+	chmod 755 "${DESTDIR}${PREFIX}/bin/${NAME}"
 
 uninstall:
 	rm -f "${DESTDIR}${PREFIX}/bin/${NAME}"

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 NAME = tinyirc
 PREFIX = /usr/local
 VERSION = 0.1.0
-BUILD_TIME = $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
+BUILD_TIME = `date -u '+%Y-%m-%dT%H:%M:%SZ'`
 
 ${NAME}:
-	go build -ldflags "-X main.version=$(VERSION) -X main.buildTime=$(BUILD_TIME)" -o ${NAME} main.go
+	go build -o $(NAME) -ldflags \
+		"-X main.version=$(VERSION) -X main.buildTime=$(BUILD_TIME)" main.go
 
 clean:
 	rm -f ${NAME}


### PR DESCRIPTION
Updates the chmod line in the Makefile to the correct path. Adds build version number and build datetime.
Proposes version 0.1.0 for the version information.